### PR TITLE
Update CMAQ_UG_tutorial_WRF-CMAQ_build_gcc.md

### DIFF
--- a/DOCS/Users_Guide/Tutorials/CMAQ_UG_tutorial_WRF-CMAQ_build_gcc.md
+++ b/DOCS/Users_Guide/Tutorials/CMAQ_UG_tutorial_WRF-CMAQ_build_gcc.md
@@ -95,7 +95,9 @@ https://cjcoats.github.io/ioapi/AVAIL.html
      git clone https://github.com/cjcoats/ioapi-3.2
      cd ioapi-3.2         ! change directory to ioapi-3.2
      git checkout -b 20200828   ! change branch to 20200828 for code updates
-     ln -s ioapi-3.2-20200828 ./ioapi-3.2  ! create a symbolic link to specify the tagged version
+     cd ..                      ! change directories to the level above ioapi-3.2
+     ln -s ioapi-3.2 ioapi-3.2-2020828 ! create a symbolic link to specify the tagged version
+     cd ioapi-3.2                      ! change back to the directory
      
 
 #### Change directories to the ioapi directory
@@ -133,6 +135,12 @@ BASEDIR = ${INSTALL}/ioapi-3.2-20200828
      mkdir $INSTALL/$BIN
       
  ### Edit the Makefile to add a path to the combined netCDF library directory
+ ### Note this is the Makefile at the ioapi-3.2 level. 
+ ### First need to copy Makefile.template Makefile
+ 
+ ```
+ cp Makefile.template Makefile
+ ```
  
  change
  
@@ -143,7 +151,7 @@ BASEDIR = ${INSTALL}/ioapi-3.2-20200828
  to
  
    ```
-   NCFLIBS    = -L /[your_install_path]/LIBRARIES/netcdf_combined/lib/ -lnetcdff -lnetcdf
+   NCFLIBS    = -L $NETCDF/lib/ -lnetcdff -lnetcdf   ! using the combined $NETCDF environment variable set above
    ```
  
  #### change into the ioapi directory and copy the existing Makeinclude.Linux2_x86_64gfort to have an extension that is the same as the BIN environment variable
@@ -167,6 +175,7 @@ BASEDIR = ${INSTALL}/ioapi-3.2-20200828
  
  
  ### Build ioapi using the following command
+ ### (Not clear where to run the make command.  Do you run it under ioapi-3.2 or ioapi-3.2/ioapi directory?
  
  
  ```
@@ -176,7 +185,7 @@ BASEDIR = ${INSTALL}/ioapi-3.2-20200828
  ### Verify that the libioapi.a and the m3tools have been successfully built
  
  ```
- ls -lrt /[your_install_path]/LIBRARIES/ioapi-3.2-20200828/Linux2_x86_64gfort_openmpi_4.0.1_gcc_9.1.0/libioapi.a
+ ls -lrt $INSTALL/ioapi-3.2-20200828/Linux2_x86_64gfort_openmpi_4.0.1_gcc_9.1.0/libioapi.a
  ```
  
  ### Note: If you get a shared object problem when trying to run m3tools such as the following:


### PR DESCRIPTION
Fahim,

I made a few suggested changes, but I  am getting the following message when I try to run make at the $INSTALL/ioapi-3.2 directory.

make |& tee make.log
(cd /proj/ie/proj/CMAS/WRF-CMAQ/LIBRARIES/openmpi_4.0.1_gcc_9.1.0/ioapi-3.2/ioapi   ; make fixed_src)
make[1]: Entering directory `/proj/ie/proj/CMAS/WRF-CMAQ/LIBRARIES/openmpi_4.0.1_gcc_9.1.0/ioapi-3.2/ioapi'
make[1]: Nothing to be done for `fixed_src'.
make[1]: Leaving directory `/proj/ie/proj/CMAS/WRF-CMAQ/LIBRARIES/openmpi_4.0.1_gcc_9.1.0/ioapi-3.2/ioapi'
make: *** No rule to make target `/proj/ie/proj/CMAS/WRF-CMAQ/LIBRARIES/openmpi_4.0.1_gcc_9.1.0/ioapi-3.2/m3tools/Makefile', needed by `configure'.  Stop.

I am able to build and install the library by changing directory into $INSTALL/ioapi-3.2/ioapi and executing make there.

We need to provide instructions to go to the ioapi-3.2/m3tools directory 
cp Makefile.nocpl Makefile
edit the Makefile to 
use $INSTALL instead of $HOME
edit Makefile to use NETCDF/lib location:
LIBS = -L${OBJDIR} -lioapi -L ${NETCDF}/lib -lnetcdff -lnetcdf $(OMPLIBS) $(ARCHLIB) $(ARCHLIBS)

I am getting an error when I try to run juldate.
./juldate: error while loading shared libraries: libgfortran.so.5: cannot open shared object file: No such file or directory

If you run into this, be sure you have loaded your module
module load openmpi_4.0.1/gcc_9.1.0

